### PR TITLE
unicode character confuses python 3 in the binder environment: delete…

### DIFF
--- a/jp_gene_viz/cytoscape.js
+++ b/jp_gene_viz/cytoscape.js
@@ -1377,7 +1377,7 @@ this.cytoscape = cytoscape;
     return Math.sqrt( dx*dx + dy*dy );
   };
 
-  // from http://en.wikipedia.org/wiki/Bézier_curve#Quadratic_curves
+  // from http://en.wikipedia.org/wiki/Bezier_curve#Quadratic_curves
   $$.math.qbezierAt = function(p0, p1, p2, t){
     return (1 - t)*(1 - t)*p0 + 2*(1 - t)*t*p1 + t*t*p2;
   };


### PR DESCRIPTION
… it.